### PR TITLE
Fixed Open Favorites at startup.

### DIFF
--- a/mangadownloader/forms/frmMain.pas
+++ b/mangadownloader/forms/frmMain.pas
@@ -1803,10 +1803,10 @@ begin
   AddToAboutStatus('Modules', IntToStr(Modules.Count));
 
   // load configfile
+  LoadOptions;
   LoadFormInformation;
   CollectLanguagesFromFiles;
   LoadMangaOptions;
-  LoadOptions;
   ApplyOptions;
 
   if not cbOptionMinimizeOnStart.Checked then


### PR DESCRIPTION
Hi!

I don't know if this is the best fix, but I think it is the easiest and most logical one.
With previous code, the app is able to detect the option _Check favorites_, but it doesn't show the Favorites tab.

Hope this helps.