### PR TITLE
Update Turkish localization

### DIFF
--- a/mangadownloader/languages/fmd.tr_TR.po
+++ b/mangadownloader/languages/fmd.tr_TR.po
@@ -579,7 +579,7 @@ msgstr "Yenile"
 
 #: taccountmanagerform.caption
 msgid "AccountManagerForm"
-msgstr ""
+msgstr "HesapYöneticisiFormu"
 
 #: taccountmanagerform.vtaccountlist.header.columns[1].text
 #| msgid "Username"
@@ -610,7 +610,7 @@ msgstr "Tamam"
 
 #: taccountsetform.caption
 msgid "Account"
-msgstr ""
+msgstr "Hesap"
 
 #: taccountsetform.ckshowpassword.caption
 msgid "Show password"
@@ -2420,11 +2420,11 @@ msgstr "Bir websitesi seç"
 
 #: twebsitesettingsform.caption
 msgid "WebsiteSettingsForm"
-msgstr ""
+msgstr "WebsiteAyarlarıFormu"
 
 #: twebsitesettingsform.edsearch.texthint
 msgid "Website name"
-msgstr ""
+msgstr "Website Adı"
 
 #: udownloadsmanager.rs_compressing
 msgid "Compressing..."


### PR DESCRIPTION
Updated according to [c3eeb39](https://github.com/riderkick/FMD/commit/c3eeb39ca8b0aa61d038c56d9a5f37a848b13ecb).

But, why Lines 581 and 2422 don't contain spaces?

If it is a mistake, i can add a new commit.