### PR TITLE
Remove download directory trailing periods

### DIFF
--- a/mangadownloader/forms/frmMain.pas
+++ b/mangadownloader/forms/frmMain.pas
@@ -2275,6 +2275,7 @@ begin
           '',
           OptionChangeUnicodeCharacter,
           OptionChangeUnicodeCharacterStr);
+      s:=ReplaceRegExpr('\.*$', s, '');
       c:=1;
       p:=links.Count;
       r:=0;


### PR DESCRIPTION
Fixes #1288.

It looks like Windows 10 does this automatically, but it might fail on older versions.