### PR TITLE
Fix address for pururin.io

### DIFF
--- a/lua/modules/Pururin.lua
+++ b/lua/modules/Pururin.lua
@@ -17,7 +17,7 @@ function GetInfo()
 end
 
 function GetPageNumber()
-  local path = 'https://api.' .. domain .. '/images'
+  local path = 'https://cdn.' .. domain .. '/assets/images/data'
   if http.get(MaybeFillHost(module.rooturl,url)) then
     local x=TXQuery.Create(http.Document)
     local s = x.xpathstring('//gallery-read/@gallery')


### PR DESCRIPTION
api.pururin.io doesn't exist, images are now served through cdn.pururin.io