### PR TITLE
MangaFox, fix getting page links

### DIFF
--- a/baseunits/modules/MangaFox.pas
+++ b/baseunits/modules/MangaFox.pas
@@ -109,15 +109,19 @@ begin
                 lst := TStringList.Create;
                 try
                   lst.CommaText := s;
-                  if page > 1 then lst.Delete(0);
                   PageLinks.AddStrings(lst);
+                  page := PageLinks.Count + 1;
                 finally
                   lst.Free;
                 end;
+              end else begin
+                key := '';
+                Sleep(200);
+                Continue;
               end;
             end;
             if PageLinks.Count >= PageNumber then Break;
-            Inc(page); Sleep(3000);
+            Sleep(3000);
           end;
         end;
       finally


### PR DESCRIPTION
This repair MangaFox getting picture links by setting key to null if we don't get information with it.
Mangafox change javascript that key is sometimes null.
And updates that if we get more than one picture in request we don't do request for it second time.
